### PR TITLE
Remove token registrations job from data processing pipeline

### DIFF
--- a/.github/workflows/data-processing.yml
+++ b/.github/workflows/data-processing.yml
@@ -52,11 +52,7 @@ on:
         required: false
         default: 'true'
         type: boolean
-      run_token_registrations:
-        description: 'Run token registrations processing'
-        required: false
-        default: 'true'
-        type: boolean
+      
 
 env:
   PYTHON_VERSION: 3.13
@@ -367,45 +363,10 @@ jobs:
         echo "🚀 Starting vote data processing..."
         python scripts/process_vote_data.py
         echo "✅ Vote data processing completed"
-
-  process-token-registrations:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_token_registrations == 'true')
-    
-    steps:
-    - name: 🔄 Checkout repository
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.ref }}
-      
-    - name: 🐍 Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-        cache: 'pip'
-        
-    - name: 📦 Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        
-    - name: 📌 Process Token Registrations
-      env:
-        SUPABASE_URL_PROD: ${{ secrets.SUPABASE_URL_PROD }}
-        SUPABASE_KEY_PROD: ${{ secrets.SUPABASE_KEY_PROD }}
-        SUPABASE_DATA_URL: ${{ secrets.SUPABASE_DATA_URL }}
-        SUPABASE_DATA_KEY: ${{ secrets.SUPABASE_DATA_KEY }}
-        COINGECKO_KEY: ${{ secrets.COINGECKO_KEY }}
-        GOOGLE_CLOUD_KEY: ${{ secrets.GOOGLE_CLOUD_KEY }}
-      run: |
-        echo "🚀 Starting token registrations processing..."
-        python scripts/process_token_registrations.py
-        echo "✅ Token registrations processing completed"
-
   notify-on-failure:
     runs-on: ubuntu-latest
     if: always() && contains(needs.*.result, 'failure')
-    needs: [process-bridge-data, fetch-mezo-users, process-musd-data, process-market-data, process-swaps-data, process-pools-data, process-dapp-data, process-vaults-data, process-vote-data, process-token-registrations]
+    needs: [process-bridge-data, fetch-mezo-users, process-musd-data, process-market-data, process-swaps-data, process-pools-data, process-dapp-data, process-vaults-data, process-vote-data]
     
     steps:
     - name: 📱 Discord notification on failure
@@ -438,9 +399,6 @@ jobs:
         fi
         if [[ "${{ needs.process-vote-data.result }}" == "failure" ]]; then
           FAILED_JOBS="${FAILED_JOBS}• Vote Data Processing\n"
-        fi
-        if [[ "${{ needs.process-token-registrations.result }}" == "failure" ]]; then
-          FAILED_JOBS="${FAILED_JOBS}• Token Registrations Processing\n"
         fi
         
         curl -X POST -H "Content-Type: application/json" \


### PR DESCRIPTION
The `process-token-registrations` job has been repeatedly failing and triggering alerts in the #data-alerts Discord channel. This PR removes the job entirely from the pipeline until the underlying issue is resolved.

Changes:
- Removed the `process-token-registrations` job
- - Removed the `run_token_registrations` workflow_dispatch input
- - Removed the `process-token-registrations` entry from the `notify-on-failure` needs list and its failure check in the shell script